### PR TITLE
All remove functions

### DIFF
--- a/Fall 2023/Operating Systems Design/project4/rufs.c
+++ b/Fall 2023/Operating Systems Design/project4/rufs.c
@@ -126,7 +126,7 @@ int writei(uint16_t ino, struct inode *inode) {
 	return EXIT_SUCCESS;
 }
 
-int dir_find_entry_location(struct inode inode_of_dir, const char *fname, int *out_direct_pointer_index, int *out_block_dirent_index){
+int dir_find_entry_and_location(struct inode inode_of_dir, const char *fname, int *out_direct_pointer_index, int *out_block_dirent_index, struct dirent *out_dirent){
 	debug("dir_find(): ENTER\n");
     debug("dir_find(): TARGET DIRENT IS \"%s\" LOCATED IN INO \"%d\"\n", fname, inode_of_dir);
     
@@ -159,6 +159,7 @@ int dir_find_entry_location(struct inode inode_of_dir, const char *fname, int *o
                 free(base);
 				*out_direct_pointer_index = i;
 				*out_block_dirent_index = j;
+				memcpy(out_dirent, current_dirent, sizeof(struct dirent));
                 return EXIT_SUCCESS;
             }
             size = size >= sizeof(struct dirent) ? size - sizeof(struct dirent) : 0;
@@ -184,18 +185,8 @@ int dir_find(uint16_t ino, const char *fname, size_t name_len, struct dirent *di
         return -1;
     }
 
-    int ret_val = dir_find_entry_location(inode_of_dir, fname, &direct_pointer_index, &block_dirent_index);
+    return dir_find_entry_and_location(inode_of_dir, fname, &direct_pointer_index, &block_dirent_index, dirent);
 
-	if(ret_val != EXIT_SUCCESS){
-		return ret_val;
-	}
-
-	struct dirent *block_of_mem = malloc(BLOCK_SIZE);
-	bio_read(inode_of_dir.direct_ptr[direct_pointer_index], block_of_mem);
-
-	memcpy(dirent, block_of_mem + block_dirent_index, sizeof(struct dirent));
-	
-	return EXIT_SUCCESS;
 }
 
 // Status: COMPLETE

--- a/Fall 2023/Operating Systems Design/project4/rufs.c
+++ b/Fall 2023/Operating Systems Design/project4/rufs.c
@@ -787,6 +787,31 @@ static int rufs_rmdir(const char *path) {
 	// Step 4: Clear inode bitmap and its data block
 	// Step 5: Call get_node_by_path() to get inode of parent directory
 	// Step 6: Call dir_remove() to remove directory entry of target directory in its parent directory
+
+	int ind_of_last_slash;
+	for(int curr_slash_ind = 0; curr_slash_ind != -1; curr_slash_ind = split_string(ind_of_last_slash, path)){
+		ind_of_last_slash = curr_slash_ind;
+	}
+	
+	int base_path_length_without_nullterm = ind_of_last_slash;
+	char *base_path = malloc(sizeof(char) * (base_path_length_without_nullterm + 1));
+
+	strncpy(base_path, path, base_path_length_without_nullterm);
+	base_path[base_path_length_without_nullterm] = '\0';
+
+
+	int dir_name_length_without_nullterm = strlen(path) - ind_of_last_slash;
+	char *dir_name = malloc(sizeof(char) * (dir_name_length_without_nullterm + 1));
+
+	strncpy(dir_name, path + base_path_length_without_nullterm, dir_name_length_without_nullterm);
+	dir_name[dir_name_length_without_nullterm] = '\0';
+
+
+	struct inode base_dir_inode;
+	get_node_by_path(base_path, ROOT_INO, &base_dir_inode);
+
+	return dir_remove(base_dir_inode, dir_name, strlen(dir_name));
+
 	return 0;
 }
 

--- a/Fall 2023/Operating Systems Design/project4/rufs.c
+++ b/Fall 2023/Operating Systems Design/project4/rufs.c
@@ -127,8 +127,8 @@ int writei(uint16_t ino, struct inode *inode) {
 }
 
 int dir_find_entry_and_location(struct inode inode_of_dir, const char *fname, size_t name_len, int *out_direct_pointer_index, int *out_block_dirent_index, struct dirent *out_dirent){
-	debug("dir_find(): ENTER\n");
-    debug("dir_find(): TARGET DIRENT IS \"%s\" LOCATED IN INO \"%d\"\n", fname, inode_of_dir);
+	debug("dir_find_entry_and_location(): ENTER\n");
+    debug("dir_find_entry_and_location(): TARGET DIRENT IS \"%s\" LOCATED IN INO \"%d\"\n", fname, inode_of_dir);
     
     void *base = malloc(BLOCK_SIZE);
     if (!base) {
@@ -153,9 +153,9 @@ int dir_find_entry_and_location(struct inode inode_of_dir, const char *fname, si
 				return -1;
 			}
             struct dirent *current_dirent = (struct dirent *)(base + j * sizeof(struct dirent));
-			debug("dir_find(): CURRENT DIRENT IS \"%s\" WITH INO \"%d\"\n", current_dirent->name, current_dirent->ino);
+			debug("dir_find_entry_and_location(): CURRENT DIRENT IS \"%s\" WITH INO \"%d\"\n", current_dirent->name, current_dirent->ino);
             if (current_dirent->valid == TRUE && strcmp(current_dirent->name, fname) == 0) {
-				debug("dir_find(): SUCCESSFULLY FOUND DIRENT \"%s\" WITH INO \"%d\"\n", current_dirent->name, current_dirent->ino);
+				debug("dir_find_entry_and_location(): SUCCESSFULLY FOUND DIRENT \"%s\" WITH INO \"%d\"\n", current_dirent->name, current_dirent->ino);
                 free(base);
 				*out_direct_pointer_index = i;
 				*out_block_dirent_index = j;
@@ -166,8 +166,8 @@ int dir_find_entry_and_location(struct inode inode_of_dir, const char *fname, si
         }
     }
     free(base);
-	debug("dir_find(): TARGET DIRENT \"%s\" NOT LOCATED IN INO \"%d\"\n", fname, inode_of_dir);
-    debug("dir_find(): EXIT\n");
+	debug("dir_find_entry_and_location(): TARGET DIRENT \"%s\" NOT LOCATED IN INO \"%d\"\n", fname, inode_of_dir);
+    debug("dir_find_entry_and_location(): EXIT\n");
     return -1;
 }
 


### PR DESCRIPTION
**Structure of changes**:
dir_find_entry_and_location() - new function that does what dir_find used to do but also has an additional 2 out parameters that specify which direct pointer points to the block the dirent was found as well as the dirents offset into the block

**dir_find()** - now changed to simply call the *dir_find_entry_and_location()* function and discard the additional new pieces of info and return just the dirent. This is nice because the public facing api of this function is totally unchanged and no refactoring needs to be done. This function simply outsources all of its work to the *dir_find_entry_and_location()* function. 

**remove_entry_from_directory()** - this will take the inode of the directory to delete an entry from as well as parameters that specify which direct pointer points to the block the dirent was found as well as the dirents offset into the block. This function sets that particular entry to 0. Notice that the information passed to this function is now easily obtained with the new *dir_find_entry_and_location()* function.

**remove_from_dir()** - another helper function that is able to take a directory, a file/dir to delete from within it and an optional parameter that helps ensure the file is of the expected type. So prior to removing it from the directory, it will check to be sure the file we want to delete is truly a file or truly a directory, depending on what was passed in. Notice it returns the appropriate error messages as you specified in the groupme. Note that I added an option to bypass file type checking if the expected file type passed in is -1. This bypass is currently not used anywhere but may provide a nice option if we do not care what we are deleting. Note that if the file we try to delete is not a file or directory we will throw an error because that is a theoretically impossible state.

**dir_remove()** - this function basically calls *remove_from_dir()* with the type checking argument set to DIRECTORY. This functions isn't 100% necessary now but the project asks for it so it can be left in. It could provide a simplified api for deleting a directory anyway because now you don't have to worry about the type checking argument, but the main reason to keep it is because we are asked to. (Plus where would the skeleton code comments live otherwise?)

**split_path_into_base_path_and_name()** - This helper function allows us to pass a pass and have it be split into base path and end file/directory. Ex: /bar/foo/baz -> base: /bar/foo, name -> baz. These are returned as out parameters.
     Special note: check the logic

**rufs_rmdir() / rufs_unlink()** - This functions are super simple now thanks to how general purpose our helper functions are. They simply call *remove_from_dir()* with the appropriate assertion parameter.

**Result**:
All remove functions are now implemented, commented, and easily extensible.

**Note about merge conflict resolution**:
I pulled from main and resolved any merge conflicts that may be created by my branch. They were mostly comments and I usually just kept both. I made sure to incorporate changes to the logic that you made, there was only 1 instance of a real merge conflict where you correctly made sure that I was checking that find_dir didn't return -1. You can look at that merge commit but I can promise it was handled properly.

**General special note**: should I comment 'Helper function' above all helper functions?